### PR TITLE
Update PyPI upload job in publish GHA workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           user: __token__
           password: ${{ env.PYPI_API_TOKEN }}
-          packages_dir: dist/
+          packages-dir: dist/


### PR DESCRIPTION
Snake-case inputs are deprecated.