### PR TITLE
Do not show old version warning for tag `latest` in docs (errata)

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,6 +1,6 @@
 {% extends "!page.html" %}
 {% block body %}
-{% if current_version and latest_version and current_version != latest_version and current_version != "latest" %}
+{% if current_version and latest_version and current_version != latest_version and current_version.name != "latest" %}
 <p>
   <strong>
     {% if current_version.is_released %}


### PR DESCRIPTION
Previous attempt was not enough (#26).